### PR TITLE
Fix: JSON 리턴할 때 한글이 깨지는 문제점 수정

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 class Config:
     SECRET_KEY = os.getenv('SECRET_KEY')
     DEBUG = False
+    JSON_AS_ASCII = False
 
 
 class DevelopmentConfig(Config):

--- a/server.py
+++ b/server.py
@@ -17,7 +17,7 @@ def transform_image(file):
     return input_batch
 
 
-def predict(input_batch):
+def predict_image(input_batch):
     labels = ['가구류', '고철류', '나무', '도기류', '비닐',
               '스티로폼', '유리병', '의류', '자전거', '전자제품',
               '종이류', '캔류', '페트병', '플라스틱류', '형광등']
@@ -38,13 +38,13 @@ def index():
 
 
 @app.post('/predict/')
-def predict(self):
+def predict():
     label = '지원하지 않는 파일 형식입니다.'
     file = request.files['file']
     try:
         input_batch = transform_image(file)
         start_time = time.time()
-        label = predict(input_batch)
+        label = predict_image(input_batch)
         end_time = time.time()
         app.logger.info(end_time - start_time)
     except UnidentifiedImageError:


### PR DESCRIPTION
## 개요
- 버그 수정

## ⛑ 주의할 점
- 없음

## 🛎 작업 내용
- predict API의 결과 (쓰레기 분류군 정보)가 한글을 포함하여 깨지는 현상을 해결
- 함수의 이름이 같은 부분 수정
- predict 함수에서 불필요한 self 인자 삭제